### PR TITLE
Minor typing fixes

### DIFF
--- a/comfy/args.py
+++ b/comfy/args.py
@@ -1,5 +1,8 @@
 from argparse import ArgumentParser
-from typing import List, AnyStr
+from typing import TYPE_CHECKING, List, AnyStr
+
+if TYPE_CHECKING:
+    from comfy.schema import Schema
 
 
 def get_arg_name(section_name, option_name):

--- a/comfy/schema.py
+++ b/comfy/schema.py
@@ -77,7 +77,7 @@ class Section(object):
             self.validate(option)
 
     def get_options(self):
-        # type: () -> List[Tuple[String, Option]]
+        # type: () -> List[Tuple[str, BaseOption]]
         """
         Returns a list of all the options defined for this section together with their names.
 
@@ -114,7 +114,8 @@ class BaseOption(object):
     """
 
     def __init__(self):
-        self.name = None  # type: str
+        # type: () -> None
+        self.name = NotImplemented  # type: str
 
     def unserialize(self, value):
         # type: (Text) -> Any

--- a/setup.py
+++ b/setup.py
@@ -13,4 +13,6 @@ setuptools.setup(
     install_requires=[
         'typing;python_version<"3.5"'
     ],
+    include_package_data=True,
+    package_data={'comfy': ['py.typed']},
 )


### PR DESCRIPTION
To mark `comfy` [as typed](https://www.python.org/dev/peps/pep-0561/#packaging-type-information), fix some smaller typing issues for the library itself that my mypy complained about.

(I pushed this version already to our devpi, since things didn't work without the changes)